### PR TITLE
Test script to render files as webpages

### DIFF
--- a/.template.yml
+++ b/.template.yml
@@ -1,0 +1,100 @@
+remote_theme: "carpentries-i18n/carp-theme"
+#------------------------------------------------------------
+# Values for this lesson.
+#------------------------------------------------------------
+
+# Which carpentry is this ("swc", "dc", "lc", or "cp")?
+# swc: Software Carpentry
+# dc: Data Carpentry
+# lc: Library Carpentry
+# cp: Carpentries (to use for instructor traning for instance)
+carpentry: "swc"
+
+# Overall title for pages.
+title: "Lesson Title"
+
+
+#------------------------------------------------------------
+# Generic settings (should not need to change).
+#------------------------------------------------------------
+
+# What kind of thing is this ("workshop" or "lesson")?
+kind: "lesson"
+
+# Magic to make URLs resolve both locally and on GitHub.
+# See https://help.github.com/articles/repository-metadata-on-github-pages/.
+# Please don't change it: <USERNAME>/<PROJECT> is correct.
+repository: <USERNAME>/<PROJECT>
+
+# Email address, no mailto:
+email: "team@carpentries.org"
+
+# Sites.
+amy_site: "https://amy.software-carpentry.org/workshops"
+carpentries_github: "https://github.com/carpentries"
+carpentries_pages: "https://carpentries.github.io"
+carpentries_site: "https://carpentries.org/"
+dc_site: "http://datacarpentry.org"
+example_repo: "https://github.com/carpentries/lesson-example"
+example_site: "https://carpentries.github.io/lesson-example"
+lc_site: "https://librarycarpentry.github.io/"
+swc_github: "https://github.com/swcarpentry"
+swc_pages: "https://swcarpentry.github.io"
+swc_site: "https://software-carpentry.org"
+template_repo: "https://github.com/carpentries/styles"
+training_site: "https://carpentries.github.io/instructor-training"
+workshop_repo: "https://github.com/carpentries/workshop-template"
+workshop_site: "https://carpentries.github.io/workshop-template"
+
+# Surveys.
+pre_survey: "https://www.surveymonkey.com/r/swc_pre_workshop_v1?workshop_id="
+post_survey: "https://www.surveymonkey.com/r/swc_post_workshop_v1?workshop_id="
+training_post_survey: "https://www.surveymonkey.com/r/post-instructor-training"
+
+# Start time in minutes (0 to be clock-independent, 540 to show a start at 09:00 am).
+start_time: 0
+
+# Specify that things in the episodes collection should be output.
+collections:
+  episodes:
+    output: true
+    permalink: /:path/index.html
+  extras:
+    output: true
+    permalink: /:path/index.html
+  locale:
+    output: true
+    permalink: /:path/index.html
+
+# Set the default layout for things in the episodes collection.
+defaults:
+  - values:
+      root: .
+      layout: page
+  - scope:
+      path: ""
+      type: episodes
+    values:
+      root: ..
+      layout: episode
+  - scope:
+      path: ""
+      type: extras
+    values:
+      root: ..
+      layout: page
+  - scope:
+      path: ""
+      type: locale
+    values:
+      root: ..
+      layout: episode
+
+# Files and directories that are not to be copied.
+exclude:
+  - Makefile
+  - bin/
+  - .Rproj.user/
+
+# Turn on built-in syntax highlighting.
+highlighter: rouge

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -2,10 +2,13 @@
 
 ### example
 # sh wrapper.sh --repo make-novice --create
+# sh wrapper.sh --repo make-novice --import
+# sh wrapper.sh --repo make-novice --account GitHubUser --import
+
 
 # create (implemented):      subroutine to create new PO files from an English lesson not currently being translated
 # import (testing):          subroutine to pull a lesson being translated from remote to make changes locally
-# render (work-in-progress): subroutine to render webpages from current PO files and export Japanese lessons to remote repos
+# webpages (work-in-progress): subroutine to render webpages from current PO files and export Japanese lessons to remote repos
 # update (to-do later):      subroutine to pull updates from remote English lesson and merge based on archived ancestor (only new sections need to be translated)
 
 
@@ -13,6 +16,7 @@ pc_user=`whoami`
 echo $pc_user account for pc `hostname`
 git_user=`git config user.name`
 git_email=`git config user.email`                                                            
+remote_account=$git_user
 echo $git_user \<${git_email}\> account detected for git
 next=false
 create=false
@@ -48,10 +52,21 @@ for op in "$@"; do
             import=true       
             next=true
             ;;
+        -a|--account)
+        shift
+            if [[ $1 != "" ]]; then
+                remote_user="${1/%\//}"       
+                next=true
+            else
+                echo("specify remote account for: $git_user")
+                remote_user=$git_user
+                next=true
+            fi
+            ;;
         -r|--repo)
         shift
             if [[ $1 != "" ]]; then
-                repo="${1/%\//}"       
+                repo="${1/%\//}"
                 next=true
             else
                 all_repo=true
@@ -96,16 +111,16 @@ echo import ${repo} : $import
 echo render webpages : $render
 
 #check if remote i18n repo exists
-root_dir=`git ls-remote https://github.com/$git_user/i18n.git | grep "ja" | wc -l`
+root_dir=`git ls-remote https://github.com/$remote_user/i18n.git | grep "ja" | wc -l`
 echo i18 repo: $root_dir
 if [ $root_dir -eq 1 ]; then
-    echo "remote found:  https://github.com/$git_user/i18n.git"
+    echo "remote found:  https://github.com/$remote_user/i18n.git"
 elif [ $root_dir -eq 0 ]; then
-    echo remote not found for user repo:  https://github.com/$git_user/i18n.git \n please create a fork
+    echo remote not found for user repo:  https://github.com/$remote_user/i18n.git \n please create a fork
     exit 1
 else
     echo ambiguous repo:
-    git ls-remote https://github.com/$git_user/i18n.git
+    git ls-remote https://github.com/$remote_user/i18n.git
     exit 1
 fi
 
@@ -330,7 +345,7 @@ if [[ $import == true ]]; then
    git init
    remotes=`git remote | grep "swc" | wc -l`
    if [[ remotes -le 0 ]]; then
-       git remote add swc https://github.com/$git_user/$repo-ja.git 
+       git remote add swc https://github.com/$remote_user/$repo-ja.git 
     fi
    git pull swc master
    git add *

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -309,6 +309,7 @@ if [[ $import == true ]]; then
 
     #create all Japanese lessons
     echo "run compile on po4gitbook"
+find
     po4gitbook/compile.sh > /dev/null 2>&1
 
     #commite updates to source PO files
@@ -348,6 +349,11 @@ if [[ $import == true ]]; then
        git remote add swc https://github.com/$remote_user/$repo-ja.git 
     fi
    git pull swc master
+
+   # remove files provided by template
+   rm -rf bin/boilerplate
+   rm -rf _layouts _includes _episodes_rmd assets bin code 
+
    git add *
    git commit -m "update lesson files"
    git push swc master


### PR DESCRIPTION
🚨work-in-progress 🚨

Script to render webpages and handle submodules for merge PO files (see #81)

    # sh wrapper.sh --repo r-novice-gapmnder --account swcarpentry-ja --import --webpages

Additions

- synchronises existing English lessons to the archived versions as submodules of `i18n`

- temporarily removes `locale` files for all lessons so only English (source) -> Japanese (target language) PO files are generated, restores these from git history after `po4gitbook` scripts are run so these are *not* changed unless `--update`  is called

- creates branches and submodules as needed and updates or resets pre-existing ones

This allows the English lessons to be handled entirely as submodules rather than creating and updating external repos

To do (mostly notes to future me):

- migrate translated repos (e.g., r-novice-gapminder-ja) to submodules of i18n rather than external repos, this will mean local changes can be done entirely within the `i18n` repo (we may need to organise this more and make sure `po4gitbook` only runs on English lessons)

- scripts to pull updates from new English lessons, this can merge updated sections into the PO files but could be tricky since David uses `master` not `gh-pages` branches (_let's leave this for another day_)

- now that I've figured out how to convert and English lesson to the multilingual format (menus with the 🌐icon), we could script this rather than forking `carpentries-i18n` / `carpentries-ES` versions (they seem to be inactive now they're using transifex), not sure how often we'll need it though so I'm okay to do it manually as required

- figure out how to call it on travis CI to build new lessons when merged, this will be a lot easier if everything is contained as a submodule I think

🚨work-in-progress 🚨

**this script has not been tested thoroughly**

Please do not use it to push to the `swcarpentry-ja` organisation repos, we should test it on forks on a user account first.