### PR TITLE
Migrate Japanese License to all SWC lessons

### DIFF
--- a/po/git-novice.ja.po
+++ b/po/git-novice.ja.po
@@ -512,72 +512,62 @@ msgid ""
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
-"全てのSoftware Carpentry と Data Carpentry の教材は\n"
-"[クリエイティブ・コモンズ・ライセンス（CC BY ライセンス）][cc-by-human]に基づ"
-"いて\n"
-"提供されています。以下の文章は[CC ライセンス][cc-by-legal]の概要です。\n"
-"（概要の内容は元の[CC BY ライセンス 4.0][cc-by-legal]の内容\n"
-"の代わりではないので、ご注意下さい。）"
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: git-novice/LICENSE.md:14
 msgid "You are free:"
-msgstr "あなたは以下の行動が許されます："
+msgstr "あなたは以下の条件に従う限り、自由に："
 
 # unordered list
 #: git-novice/LICENSE.md:16
-msgid ""
-"* to **Share**---copy and redistribute the material in any medium or format"
-msgstr "* 教材内容を複製、配布・共有、そして別の形式に変換する事"
+msgid "* to **Share**---copy and redistribute the material in any medium or format"
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
 # unordered list
 #: git-novice/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr "* 教材内容を変更、もしくは教材を基に新しい教材を作ることができます"
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: git-novice/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr "（それがたとえ営利目的であっても）"
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: git-novice/LICENSE.md:21
 msgid ""
 "The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
-"以上の行動は、ライセンスの条件を満たしていれば\n"
-"誰にでも自由に行使する権利があり、著作者・ライセンサーはその権利を取り消すこ"
-"とができません。"
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: git-novice/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr "以下の条件を満たせば、上記の行動が許されます："
+msgstr "あなたの従うべき条件は以下の通りです："
 
 # unordered list
 #: git-novice/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr ""
-"* **著作権の表示**---使用者は必ず、教材の著作権がどこに帰属しているかを明確に"
-"する事"
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: git-novice/LICENSE.md:27
 msgid ""
 "  your work is derived from work that is Copyright © Software\n"
 "  Carpentry and, where practical, linking to\n"
-"  https://software-carpentry.org/), provide a [link to the\n"
+"  http://software-carpentry.org/), provide a [link to the\n"
 "  license][cc-by-human], and indicate if changes were made. You may do\n"
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
-"  （あなたが提供する教材がSoftware Carpentryの著作物を基に制作・引用されたこ"
-"と、\n"
-"  そして可能であればSoftware Carpentryへのリンク（https://software-carpentry."
-"org/）を提示すること）、\n"
-"  [CC ライセンス][cc-by-human]へのリンクを含むこと、そして、教材内容を変更し"
-"た場合、\n"
-"  内容が変更されたことを明確にする事。著作権の表示がどのように記載されるか"
-"は、\n"
-"  製作者の自由ですが、くれぐれもライセンサー（私達）が「あなた、もしくはあな"
-"たの作品を公認した」\n"
-"  というような言い回しがないようにお気をつけ下さい。"
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: git-novice/LICENSE.md:34
 msgid ""
@@ -585,9 +575,9 @@ msgid ""
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
-"**新たな利用制限の追加**---他者が作品を同ライセンスに基づいて使用する場合、\n"
-"あなたはその使用を妨げる、もしくは制限するような技術・法的規定を\n"
-"作品に適用することを禁じます。"
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: git-novice/LICENSE.md:38
 msgid "Notices:"
@@ -596,7 +586,7 @@ msgstr "ご注意："
 # unordered list
 #: git-novice/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr "* あなたは、パブリック・ドメイン（Public Domain）に属している、"
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: git-novice/LICENSE.md:41
 msgid ""
@@ -607,12 +597,12 @@ msgid ""
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
-"  もしくは利用制限のない個所に関しては、\n"
-"  ライセンスの規定に従う必要がありません。\n"
-"* 保証は提供されていません。ライセンスはあなたの利用に必要な許諾を与える\n"
-"  保証はありません。例えば、パブリシティ権、肖像権、人格権など、\n"
-"  他の諸権利によって資料の利用を\n"
-"  制限されることがあります。"
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
 # header
 #: git-novice/LICENSE.md:48
@@ -622,16 +612,14 @@ msgstr "## ソフトウェア"
 #: git-novice/LICENSE.md:50
 msgid ""
 "Except where otherwise noted, the example programs and other software\n"
-"provided by Software Carpentry and Data Carpentry are made available under "
-"the\n"
+"provided by Software Carpentry and Data Carpentry are made available under the\n"
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
-"別途で記載されていない限り、Software CarpentryとData Carpentryで使われてい"
-"る\n"
-"プログラム・ソフトウェアは全て\n"
-"[OSI][osi]（Open Systems Interconnection）に認定された\n"
-"[MIT ライセンス][mit-license]に基づいて提供されています。"
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: git-novice/LICENSE.md:55
 msgid ""
@@ -643,22 +631,19 @@ msgid ""
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
-"ここに、以下の条件に従うことと引き換えに、どなたにも無償でこのソフトウェ"
-"ア、\n"
-"そしてそれに関する資料（以降「ソフトウェア」）を制限なく使用、\n"
-"複製、編集、変更、併合、\n"
-"公開、配布、サブライセンス、そして・もしくは\n"
-"ソフトウェアのコピーを売ること、そして\n"
-"その他の人にも同じ権限を与えることを\n"
-"許可します："
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: git-novice/LICENSE.md:63
 msgid ""
 "The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
-"上記の著作権内容、そしてこの許可書内容を全ての\n"
-"複製されたソフトウェアに含めること。"
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: git-novice/LICENSE.md:66
 msgid ""
@@ -670,26 +655,26 @@ msgid ""
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
-"*ソフトウェアは「ありのまま」の状態で提供されており、記載されているかに\n"
-"関わらず、どのような保証も提供されていません。これは、商品性の保証、\n"
-"特定の目的のための使用についての保証、非侵害保証などが含まれます。\n"
-"いかなる場合でも著作者・著作権者は、ソフトウェアによって、\n"
-"またはソフトウェアとの何らかの関係によって生じた\n"
-"負債、損害、その他の責任を一切\n"
-"負いません。*"
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
 # header
 #: git-novice/LICENSE.md:74
 msgid "## Trademark"
-msgstr "## トレードマーク"
+msgstr "## 商標"
 
 #: git-novice/LICENSE.md:76
 msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"「Software Carpentry」と「Data Carpentry」のロゴは\n"
-"公式に登録された[Community Initiatives][CI]のトレードマークです。"
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: git-novice/LICENSE.md:79
 msgid ""
@@ -703,7 +688,8 @@ msgstr ""
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
 "[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
-"[osi]: https://opensource.org"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: git-novice/README.md:1
 msgid ""

--- a/po/git-novice.ja.po
+++ b/po/git-novice.ja.po
@@ -673,7 +673,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: git-novice/LICENSE.md:79

--- a/po/make-novice.ja.po
+++ b/po/make-novice.ja.po
@@ -517,7 +517,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: make-novice/LICENSE.md:79

--- a/po/make-novice.ja.po
+++ b/po/make-novice.ja.po
@@ -328,108 +328,146 @@ msgid "[contact]: mailto:admin@software-carpentry.org\n"
 "[swc-site]: http://software-carpentry.org/"
 msgstr ""
 
-#: make-novice/LICENSE.md:1
 # Front Matter
-msgid "---\n"
+#: make-novice/LICENSE.md:1
+msgid ""
+"---\n"
 "layout: page\n"
 "title: \"Licenses\"\n"
 "root: .\n"
 "---"
 msgstr ""
+"---\n"
+"layout: page\n"
+"title: \"ライセンス\"\n"
+"root: .\n"
+"---"
 
-#: make-novice/LICENSE.md:6
 # header
+#: make-novice/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr ""
+msgstr "## 教材"
 
 #: make-novice/LICENSE.md:8
-msgid "All Software Carpentry and Data Carpentry instructional material is\n"
+msgid ""
+"All Software Carpentry and Data Carpentry instructional material is\n"
 "made available under the [Creative Commons Attribution\n"
 "license][cc-by-human]. The following is a human-readable summary of\n"
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: make-novice/LICENSE.md:14
 msgid "You are free:"
-msgstr ""
+msgstr "あなたは以下の条件に従う限り、自由に："
 
+# unordered list
 #: make-novice/LICENSE.md:16
-# unordered list
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr ""
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
-#: make-novice/LICENSE.md:17
 # unordered list
+#: make-novice/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr ""
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: make-novice/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr ""
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: make-novice/LICENSE.md:21
-msgid "The licensor cannot revoke these freedoms as long as you follow the\n"
+msgid ""
+"The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: make-novice/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr ""
+msgstr "あなたの従うべき条件は以下の通りです："
 
-#: make-novice/LICENSE.md:26
 # unordered list
+#: make-novice/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr ""
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: make-novice/LICENSE.md:27
-msgid "  your work is derived from work that is Copyright © Software\n"
+msgid ""
+"  your work is derived from work that is Copyright © Software\n"
 "  Carpentry and, where practical, linking to\n"
 "  http://software-carpentry.org/), provide a [link to the\n"
 "  license][cc-by-human], and indicate if changes were made. You may do\n"
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: make-novice/LICENSE.md:34
-msgid "**No additional restrictions**---You may not apply legal terms or\n"
+msgid ""
+"**No additional restrictions**---You may not apply legal terms or\n"
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: make-novice/LICENSE.md:38
 msgid "Notices:"
-msgstr ""
+msgstr "ご注意："
 
-#: make-novice/LICENSE.md:40
 # unordered list
+#: make-novice/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr ""
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: make-novice/LICENSE.md:41
-msgid "  material in the public domain or where your use is permitted by an\n"
+msgid ""
+"  material in the public domain or where your use is permitted by an\n"
 "  applicable exception or limitation.\n"
 "* No warranties are given. The license may not give you all of the\n"
 "  permissions necessary for your intended use. For example, other\n"
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
-#: make-novice/LICENSE.md:48
-#: make-novice/setup.md:33
 # header
+#: make-novice/LICENSE.md:48
 msgid "## Software"
-msgstr ""
+msgstr "## ソフトウェア"
 
 #: make-novice/LICENSE.md:50
-msgid "Except where otherwise noted, the example programs and other software\n"
+msgid ""
+"Except where otherwise noted, the example programs and other software\n"
 "provided by Software Carpentry and Data Carpentry are made available under the\n"
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: make-novice/LICENSE.md:55
-msgid "Permission is hereby granted, free of charge, to any person obtaining\n"
+msgid ""
+"Permission is hereby granted, free of charge, to any person obtaining\n"
 "a copy of this software and associated documentation files (the\n"
 "\"Software\"), to deal in the Software without restriction, including\n"
 "without limitation the rights to use, copy, modify, merge, publish,\n"
@@ -437,14 +475,23 @@ msgid "Permission is hereby granted, free of charge, to any person obtaining\n"
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: make-novice/LICENSE.md:63
-msgid "The above copyright notice and this permission notice shall be\n"
+msgid ""
+"The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: make-novice/LICENSE.md:66
-msgid "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
+msgid ""
+"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
 "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
 "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
 "NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n"
@@ -452,24 +499,41 @@ msgid "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
-#: make-novice/LICENSE.md:74
 # header
+#: make-novice/LICENSE.md:74
 msgid "## Trademark"
-msgstr ""
+msgstr "## 商標"
 
 #: make-novice/LICENSE.md:76
-msgid "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
+msgid ""
+"\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: make-novice/LICENSE.md:79
-msgid "[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
+msgid ""
+"[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
 "[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
 "[osi]: https://opensource.org"
 msgstr ""
+"[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
+"[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
+"[mit-license]: https://opensource.org/licenses/mit-license.html\n"
+"[ci]: http://communityin.org/\n"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: make-novice/README.md:1
 msgid "[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3265286.svg)](https://doi.org/10.5281/zenodo.3265286)\n"

--- a/po/python-novice-gapminder.ja.po
+++ b/po/python-novice-gapminder.ja.po
@@ -540,7 +540,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: python-novice-gapminder/LICENSE.md:79

--- a/po/python-novice-gapminder.ja.po
+++ b/po/python-novice-gapminder.ja.po
@@ -360,11 +360,16 @@ msgid ""
 "root: .\n"
 "---"
 msgstr ""
+"---\n"
+"layout: page\n"
+"title: \"ライセンス\"\n"
+"root: .\n"
+"---"
 
 # header
 #: python-novice-gapminder/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr ""
+msgstr "## 教材"
 
 #: python-novice-gapminder/LICENSE.md:8
 msgid ""
@@ -374,39 +379,46 @@ msgid ""
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: python-novice-gapminder/LICENSE.md:14
 msgid "You are free:"
-msgstr ""
+msgstr "あなたは以下の条件に従う限り、自由に："
 
 # unordered list
 #: python-novice-gapminder/LICENSE.md:16
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr ""
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
 # unordered list
 #: python-novice-gapminder/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr ""
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: python-novice-gapminder/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr ""
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: python-novice-gapminder/LICENSE.md:21
 msgid ""
 "The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: python-novice-gapminder/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr ""
+msgstr "あなたの従うべき条件は以下の通りです："
 
 # unordered list
 #: python-novice-gapminder/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr ""
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: python-novice-gapminder/LICENSE.md:27
 msgid ""
@@ -417,6 +429,12 @@ msgid ""
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: python-novice-gapminder/LICENSE.md:34
 msgid ""
@@ -424,15 +442,18 @@ msgid ""
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: python-novice-gapminder/LICENSE.md:38
 msgid "Notices:"
-msgstr ""
+msgstr "ご注意："
 
 # unordered list
 #: python-novice-gapminder/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr ""
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: python-novice-gapminder/LICENSE.md:41
 msgid ""
@@ -443,11 +464,17 @@ msgid ""
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
 # header
 #: python-novice-gapminder/LICENSE.md:48
 msgid "## Software"
-msgstr ""
+msgstr "## ソフトウェア"
 
 #: python-novice-gapminder/LICENSE.md:50
 msgid ""
@@ -456,6 +483,10 @@ msgid ""
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: python-novice-gapminder/LICENSE.md:55
 msgid ""
@@ -467,12 +498,19 @@ msgid ""
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: python-novice-gapminder/LICENSE.md:63
 msgid ""
 "The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: python-novice-gapminder/LICENSE.md:66
 msgid ""
@@ -484,17 +522,26 @@ msgid ""
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
 # header
 #: python-novice-gapminder/LICENSE.md:74
 msgid "## Trademark"
-msgstr ""
+msgstr "## 商標"
 
 #: python-novice-gapminder/LICENSE.md:76
 msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: python-novice-gapminder/LICENSE.md:79
 msgid ""
@@ -504,6 +551,12 @@ msgid ""
 "[ci]: http://communityin.org/\n"
 "[osi]: https://opensource.org"
 msgstr ""
+"[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
+"[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
+"[mit-license]: https://opensource.org/licenses/mit-license.html\n"
+"[ci]: http://communityin.org/\n"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: python-novice-gapminder/README.md:1
 msgid ""

--- a/po/python-novice-inflammation.ja.po
+++ b/po/python-novice-inflammation.ja.po
@@ -664,7 +664,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: python-novice-inflammation/LICENSE.md:79

--- a/po/python-novice-inflammation.ja.po
+++ b/po/python-novice-inflammation.ja.po
@@ -486,14 +486,14 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: page\n"
-"title: \"Licenses\"\n"
+"title: \"ライセンス\"\n"
 "root: .\n"
 "---"
 
 # header
 #: python-novice-inflammation/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr "## Instructional Material"
+msgstr "## 教材"
 
 #: python-novice-inflammation/LICENSE.md:8
 msgid ""
@@ -503,46 +503,46 @@ msgid ""
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
-"All Software Carpentry and Data Carpentry instructional material is\n"
-"made available under the [Creative Commons Attribution\n"
-"license][cc-by-human]. The following is a human-readable summary of\n"
-"(and not a substitute for) the [full legal text of the CC BY 4.0\n"
-"license][cc-by-legal]."
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: python-novice-inflammation/LICENSE.md:14
 msgid "You are free:"
-msgstr "You are free:"
+msgstr "あなたは以下の条件に従う限り、自由に："
 
 # unordered list
 #: python-novice-inflammation/LICENSE.md:16
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr "* to **Share**---copy and redistribute the material in any medium or format"
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
 # unordered list
 #: python-novice-inflammation/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr "* to **Adapt**---remix, transform, and build upon the material"
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: python-novice-inflammation/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr "for any purpose, even commercially."
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: python-novice-inflammation/LICENSE.md:21
 msgid ""
 "The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
-"The licensor cannot revoke these freedoms as long as you follow the\n"
-"license terms."
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: python-novice-inflammation/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr "Under the following terms:"
+msgstr "あなたの従うべき条件は以下の通りです："
 
 # unordered list
 #: python-novice-inflammation/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr "* **Attribution**---You must give appropriate credit (mentioning that"
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: python-novice-inflammation/LICENSE.md:27
 msgid ""
@@ -553,12 +553,12 @@ msgid ""
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
-"  your work is derived from work that is Copyright © Software\n"
-"  Carpentry and, where practical, linking to\n"
-"  http://software-carpentry.org/), provide a [link to the\n"
-"  license][cc-by-human], and indicate if changes were made. You may do\n"
-"  so in any reasonable manner, but not in any way that suggests the\n"
-"  licensor endorses you or your use."
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: python-novice-inflammation/LICENSE.md:34
 msgid ""
@@ -566,18 +566,18 @@ msgid ""
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
-"**No additional restrictions**---You may not apply legal terms or\n"
-"technological measures that legally restrict others from doing\n"
-"anything the license permits.  With the understanding that:"
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: python-novice-inflammation/LICENSE.md:38
 msgid "Notices:"
-msgstr "Notices:"
+msgstr "ご注意："
 
 # unordered list
 #: python-novice-inflammation/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr "* You do not have to comply with the license for elements of the"
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: python-novice-inflammation/LICENSE.md:41
 msgid ""
@@ -588,17 +588,17 @@ msgid ""
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
-"  material in the public domain or where your use is permitted by an\n"
-"  applicable exception or limitation.\n"
-"* No warranties are given. The license may not give you all of the\n"
-"  permissions necessary for your intended use. For example, other\n"
-"  rights such as publicity, privacy, or moral rights may limit how you\n"
-"  use the material."
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
 # header
 #: python-novice-inflammation/LICENSE.md:48
 msgid "## Software"
-msgstr "## Software"
+msgstr "## ソフトウェア"
 
 #: python-novice-inflammation/LICENSE.md:50
 msgid ""
@@ -607,10 +607,10 @@ msgid ""
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
-"Except where otherwise noted, the example programs and other software\n"
-"provided by Software Carpentry and Data Carpentry are made available under the\n"
-"[OSI][osi]-approved\n"
-"[MIT license][mit-license]."
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: python-novice-inflammation/LICENSE.md:55
 msgid ""
@@ -622,21 +622,19 @@ msgid ""
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
-"Permission is hereby granted, free of charge, to any person obtaining\n"
-"a copy of this software and associated documentation files (the\n"
-"\"Software\"), to deal in the Software without restriction, including\n"
-"without limitation the rights to use, copy, modify, merge, publish,\n"
-"distribute, sublicense, and/or sell copies of the Software, and to\n"
-"permit persons to whom the Software is furnished to do so, subject to\n"
-"the following conditions:"
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: python-novice-inflammation/LICENSE.md:63
 msgid ""
 "The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
-"The above copyright notice and this permission notice shall be\n"
-"included in all copies or substantial portions of the Software."
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: python-novice-inflammation/LICENSE.md:66
 msgid ""
@@ -648,26 +646,26 @@ msgid ""
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
-"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
-"EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
-"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
-"NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n"
-"LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n"
-"OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
-"WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
 # header
 #: python-novice-inflammation/LICENSE.md:74
 msgid "## Trademark"
-msgstr "## Trademark"
+msgstr "## 商標"
 
 #: python-novice-inflammation/LICENSE.md:76
 msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
-"are registered trademarks of [Community Initiatives][CI]."
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: python-novice-inflammation/LICENSE.md:79
 msgid ""
@@ -681,7 +679,8 @@ msgstr ""
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
 "[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
-"[osi]: https://opensource.org"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 # header
 #: python-novice-inflammation/README.md:1

--- a/po/r-novice-gapminder.ja.po
+++ b/po/r-novice-gapminder.ja.po
@@ -476,7 +476,7 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: page\n"
-"title: \"Licenses\"\n"
+"title: \"ライセンス\"\n"
 "root: .\n"
 "---"
 

--- a/po/r-novice-gapminder.ja.po
+++ b/po/r-novice-gapminder.ja.po
@@ -654,7 +654,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: r-novice-gapminder/LICENSE.md:79

--- a/po/r-novice-inflammation.ja.po
+++ b/po/r-novice-inflammation.ja.po
@@ -334,107 +334,146 @@ msgid "[contact]: mailto:admin@software-carpentry.org\n"
 "[swc-site]: http://software-carpentry.org/"
 msgstr ""
 
-#: r-novice-inflammation/LICENSE.md:1
 # Front Matter
-msgid "---\n"
+#: r-novice-inflammation/LICENSE.md:1
+msgid ""
+"---\n"
 "layout: page\n"
 "title: \"Licenses\"\n"
 "root: .\n"
 "---"
 msgstr ""
+"---\n"
+"layout: page\n"
+"title: \"ライセンス\"\n"
+"root: .\n"
+"---"
 
-#: r-novice-inflammation/LICENSE.md:6
 # header
+#: r-novice-inflammation/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr ""
+msgstr "## 教材"
 
 #: r-novice-inflammation/LICENSE.md:8
-msgid "All Software Carpentry and Data Carpentry instructional material is\n"
+msgid ""
+"All Software Carpentry and Data Carpentry instructional material is\n"
 "made available under the [Creative Commons Attribution\n"
 "license][cc-by-human]. The following is a human-readable summary of\n"
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: r-novice-inflammation/LICENSE.md:14
 msgid "You are free:"
-msgstr ""
+msgstr "あなたは以下の条件に従う限り、自由に："
 
+# unordered list
 #: r-novice-inflammation/LICENSE.md:16
-# unordered list
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr ""
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
-#: r-novice-inflammation/LICENSE.md:17
 # unordered list
+#: r-novice-inflammation/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr ""
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: r-novice-inflammation/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr ""
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: r-novice-inflammation/LICENSE.md:21
-msgid "The licensor cannot revoke these freedoms as long as you follow the\n"
+msgid ""
+"The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: r-novice-inflammation/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr ""
+msgstr "あなたの従うべき条件は以下の通りです："
 
-#: r-novice-inflammation/LICENSE.md:26
 # unordered list
+#: r-novice-inflammation/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr ""
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: r-novice-inflammation/LICENSE.md:27
-msgid "  your work is derived from work that is Copyright © Software\n"
+msgid ""
+"  your work is derived from work that is Copyright © Software\n"
 "  Carpentry and, where practical, linking to\n"
 "  http://software-carpentry.org/), provide a [link to the\n"
 "  license][cc-by-human], and indicate if changes were made. You may do\n"
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: r-novice-inflammation/LICENSE.md:34
-msgid "**No additional restrictions**---You may not apply legal terms or\n"
+msgid ""
+"**No additional restrictions**---You may not apply legal terms or\n"
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: r-novice-inflammation/LICENSE.md:38
 msgid "Notices:"
-msgstr ""
+msgstr "ご注意："
 
-#: r-novice-inflammation/LICENSE.md:40
 # unordered list
+#: r-novice-inflammation/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr ""
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: r-novice-inflammation/LICENSE.md:41
-msgid "  material in the public domain or where your use is permitted by an\n"
+msgid ""
+"  material in the public domain or where your use is permitted by an\n"
 "  applicable exception or limitation.\n"
 "* No warranties are given. The license may not give you all of the\n"
 "  permissions necessary for your intended use. For example, other\n"
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
-#: r-novice-inflammation/LICENSE.md:48
 # header
+#: r-novice-inflammation/LICENSE.md:48
 msgid "## Software"
-msgstr ""
+msgstr "## ソフトウェア"
 
 #: r-novice-inflammation/LICENSE.md:50
-msgid "Except where otherwise noted, the example programs and other software\n"
+msgid ""
+"Except where otherwise noted, the example programs and other software\n"
 "provided by Software Carpentry and Data Carpentry are made available under the\n"
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: r-novice-inflammation/LICENSE.md:55
-msgid "Permission is hereby granted, free of charge, to any person obtaining\n"
+msgid ""
+"Permission is hereby granted, free of charge, to any person obtaining\n"
 "a copy of this software and associated documentation files (the\n"
 "\"Software\"), to deal in the Software without restriction, including\n"
 "without limitation the rights to use, copy, modify, merge, publish,\n"
@@ -442,14 +481,23 @@ msgid "Permission is hereby granted, free of charge, to any person obtaining\n"
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: r-novice-inflammation/LICENSE.md:63
-msgid "The above copyright notice and this permission notice shall be\n"
+msgid ""
+"The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: r-novice-inflammation/LICENSE.md:66
-msgid "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
+msgid ""
+"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
 "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
 "MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
 "NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n"
@@ -457,24 +505,41 @@ msgid "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
-#: r-novice-inflammation/LICENSE.md:74
 # header
+#: r-novice-inflammation/LICENSE.md:74
 msgid "## Trademark"
-msgstr ""
+msgstr "## 商標"
 
 #: r-novice-inflammation/LICENSE.md:76
-msgid "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
+msgid ""
+"\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: r-novice-inflammation/LICENSE.md:79
-msgid "[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
+msgid ""
+"[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
 "[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
 "[osi]: https://opensource.org"
 msgstr ""
+"[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
+"[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
+"[mit-license]: https://opensource.org/licenses/mit-license.html\n"
+"[ci]: http://communityin.org/\n"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: r-novice-inflammation/README.md:1
 msgid "[![Build Status](https://travis-ci.org/swcarpentry/r-novice-inflammation.svg?branch=master)](https://travis-ci.org/swcarpentry/r-novice-inflammation)\n"

--- a/po/r-novice-inflammation.ja.po
+++ b/po/r-novice-inflammation.ja.po
@@ -523,7 +523,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: r-novice-inflammation/LICENSE.md:79

--- a/po/shell-novice.ja.po
+++ b/po/shell-novice.ja.po
@@ -695,7 +695,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: shell-novice/LICENSE.md:79

--- a/po/shell-novice.ja.po
+++ b/po/shell-novice.ja.po
@@ -517,14 +517,14 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: page\n"
-"title: \"Licenses\"\n"
+"title: \"ライセンス\"\n"
 "root: .\n"
 "---"
 
 # header
 #: shell-novice/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr "## Instructional Material"
+msgstr "## 教材"
 
 #: shell-novice/LICENSE.md:8
 msgid ""
@@ -534,46 +534,46 @@ msgid ""
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
-"All Software Carpentry and Data Carpentry instructional material is\n"
-"made available under the [Creative Commons Attribution\n"
-"license][cc-by-human]. The following is a human-readable summary of\n"
-"(and not a substitute for) the [full legal text of the CC BY 4.0\n"
-"license][cc-by-legal]."
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
 #: shell-novice/LICENSE.md:14
 msgid "You are free:"
-msgstr "You are free:"
+msgstr "あなたは以下の条件に従う限り、自由に："
 
 # unordered list
 #: shell-novice/LICENSE.md:16
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr "* to **Share**---copy and redistribute the material in any medium or format"
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
 # unordered list
 #: shell-novice/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr "* to **Adapt**---remix, transform, and build upon the material"
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
 #: shell-novice/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr "for any purpose, even commercially."
+msgstr "営利目的も含め、どのような目的でも。"
 
 #: shell-novice/LICENSE.md:21
 msgid ""
 "The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
-"The licensor cannot revoke these freedoms as long as you follow the\n"
-"license terms."
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
 #: shell-novice/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr "Under the following terms:"
+msgstr "あなたの従うべき条件は以下の通りです："
 
 # unordered list
 #: shell-novice/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr "* **Attribution**---You must give appropriate credit (mentioning that"
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
 #: shell-novice/LICENSE.md:27
 msgid ""
@@ -584,12 +584,12 @@ msgid ""
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
-"  your work is derived from work that is Copyright © Software\n"
-"  Carpentry and, where practical, linking to\n"
-"  http://software-carpentry.org/), provide a [link to the\n"
-"  license][cc-by-human], and indicate if changes were made. You may do\n"
-"  so in any reasonable manner, but not in any way that suggests the\n"
-"  licensor endorses you or your use."
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
 #: shell-novice/LICENSE.md:34
 msgid ""
@@ -597,18 +597,18 @@ msgid ""
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
-"**No additional restrictions**---You may not apply legal terms or\n"
-"technological measures that legally restrict others from doing\n"
-"anything the license permits.  With the understanding that:"
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
 #: shell-novice/LICENSE.md:38
 msgid "Notices:"
-msgstr "Notices:"
+msgstr "ご注意："
 
 # unordered list
 #: shell-novice/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr "* You do not have to comply with the license for elements of the"
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
 #: shell-novice/LICENSE.md:41
 msgid ""
@@ -619,17 +619,17 @@ msgid ""
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
-"  material in the public domain or where your use is permitted by an\n"
-"  applicable exception or limitation.\n"
-"* No warranties are given. The license may not give you all of the\n"
-"  permissions necessary for your intended use. For example, other\n"
-"  rights such as publicity, privacy, or moral rights may limit how you\n"
-"  use the material."
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
 # header
 #: shell-novice/LICENSE.md:48
 msgid "## Software"
-msgstr "## Software"
+msgstr "## ソフトウェア"
 
 #: shell-novice/LICENSE.md:50
 msgid ""
@@ -638,10 +638,10 @@ msgid ""
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
-"Except where otherwise noted, the example programs and other software\n"
-"provided by Software Carpentry and Data Carpentry are made available under the\n"
-"[OSI][osi]-approved\n"
-"[MIT license][mit-license]."
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
 #: shell-novice/LICENSE.md:55
 msgid ""
@@ -653,21 +653,19 @@ msgid ""
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
-"Permission is hereby granted, free of charge, to any person obtaining\n"
-"a copy of this software and associated documentation files (the\n"
-"\"Software\"), to deal in the Software without restriction, including\n"
-"without limitation the rights to use, copy, modify, merge, publish,\n"
-"distribute, sublicense, and/or sell copies of the Software, and to\n"
-"permit persons to whom the Software is furnished to do so, subject to\n"
-"the following conditions:"
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
 #: shell-novice/LICENSE.md:63
 msgid ""
 "The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
-"The above copyright notice and this permission notice shall be\n"
-"included in all copies or substantial portions of the Software."
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
 #: shell-novice/LICENSE.md:66
 msgid ""
@@ -679,40 +677,41 @@ msgid ""
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
-"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
-"EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
-"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
-"NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n"
-"LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n"
-"OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
-"WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
 # header
 #: shell-novice/LICENSE.md:74
 msgid "## Trademark"
-msgstr "## Trademark"
+msgstr "## 商標"
 
 #: shell-novice/LICENSE.md:76
 msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
-"are registered trademarks of [Community Initiatives][CI]."
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
 #: shell-novice/LICENSE.md:79
 msgid ""
 "[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
-"[mit-license]: http://opensource.org/licenses/mit-license.html\n"
+"[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
-"[osi]: http://opensource.org"
+"[osi]: https://opensource.org"
 msgstr ""
 "[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
-"[mit-license]: http://opensource.org/licenses/mit-license.html\n"
+"[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
-"[osi]: http://opensource.org"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: shell-novice/README.md:1
 msgid ""

--- a/po/sql-novice-survey.ja.po
+++ b/po/sql-novice-survey.ja.po
@@ -469,7 +469,7 @@ msgstr ""
 "[swc-site]: http://software-carpentry.org/"
 
 # Front Matter
-#: sql-novice-survey/LICENSE.md:1
+#: shell-novice/LICENSE.md:1
 msgid ""
 "---\n"
 "layout: page\n"
@@ -479,16 +479,16 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: page\n"
-"title: \"Licenses\"\n"
+"title: \"ライセンス\"\n"
 "root: .\n"
 "---"
 
 # header
-#: sql-novice-survey/LICENSE.md:6
+#: shell-novice/LICENSE.md:6
 msgid "## Instructional Material"
-msgstr "## Instructional Material"
+msgstr "## 教材"
 
-#: sql-novice-survey/LICENSE.md:8
+#: shell-novice/LICENSE.md:8
 msgid ""
 "All Software Carpentry and Data Carpentry instructional material is\n"
 "made available under the [Creative Commons Attribution\n"
@@ -496,48 +496,48 @@ msgid ""
 "(and not a substitute for) the [full legal text of the CC BY 4.0\n"
 "license][cc-by-legal]."
 msgstr ""
-"All Software Carpentry and Data Carpentry instructional material is\n"
-"made available under the [Creative Commons Attribution\n"
-"license][cc-by-human]. The following is a human-readable summary of\n"
-"(and not a substitute for) the [full legal text of the CC BY 4.0\n"
-"license][cc-by-legal]."
+"ソフトウェアカーペントリーとData Carpentryに関する全ての教材は\n"
+"[クリエイティブ・コモンズ 表示ライセンス](https://creativecommons.org/licenses/by/4.0/deed.ja)\n"
+"の下で利用可能です。以下は、\n"
+"[表示4.0 国際(CC BY 4.0)ライセンスの完全な法的テキスト](https://creativecommons.org/licenses/by/4.0/legalcode.ja)の\n"
+"人が読んでわかりやすいようにした要約です。(ライセンスの代わりになるものではありません。）"
 
-#: sql-novice-survey/LICENSE.md:14
+#: shell-novice/LICENSE.md:14
 msgid "You are free:"
-msgstr "You are free:"
+msgstr "あなたは以下の条件に従う限り、自由に："
 
 # unordered list
-#: sql-novice-survey/LICENSE.md:16
+#: shell-novice/LICENSE.md:16
 msgid "* to **Share**---copy and redistribute the material in any medium or format"
-msgstr "* to **Share**---copy and redistribute the material in any medium or format"
+msgstr "* **共有**---どのようなメディアやフォーマットでも資料を複製したり、再配布できます"
 
 # unordered list
-#: sql-novice-survey/LICENSE.md:17
+#: shell-novice/LICENSE.md:17
 msgid "* to **Adapt**---remix, transform, and build upon the material"
-msgstr "* to **Adapt**---remix, transform, and build upon the material"
+msgstr "* **翻案**---マテリアルをリミックスしたり、改変したり、別の作品のベースにしたりできます\n"
 
-#: sql-novice-survey/LICENSE.md:19
+#: shell-novice/LICENSE.md:19
 msgid "for any purpose, even commercially."
-msgstr "for any purpose, even commercially."
+msgstr "営利目的も含め、どのような目的でも。"
 
-#: sql-novice-survey/LICENSE.md:21
+#: shell-novice/LICENSE.md:21
 msgid ""
 "The licensor cannot revoke these freedoms as long as you follow the\n"
 "license terms."
 msgstr ""
-"The licensor cannot revoke these freedoms as long as you follow the\n"
-"license terms."
+"あなたがライセンスの条件に従っている限り、許諾者がこれらの自由を\n"
+"取り消すことはできません。"
 
-#: sql-novice-survey/LICENSE.md:24
+#: shell-novice/LICENSE.md:24
 msgid "Under the following terms:"
-msgstr "Under the following terms:"
+msgstr "あなたの従うべき条件は以下の通りです："
 
 # unordered list
-#: sql-novice-survey/LICENSE.md:26
+#: shell-novice/LICENSE.md:26
 msgid "* **Attribution**---You must give appropriate credit (mentioning that"
-msgstr "* **Attribution**---You must give appropriate credit (mentioning that"
+msgstr "* **表示**---あなたは 適切なクレジットを表示し (あなたの作品が"
 
-#: sql-novice-survey/LICENSE.md:27
+#: shell-novice/LICENSE.md:27
 msgid ""
 "  your work is derived from work that is Copyright © Software\n"
 "  Carpentry and, where practical, linking to\n"
@@ -546,33 +546,33 @@ msgid ""
 "  so in any reasonable manner, but not in any way that suggests the\n"
 "  licensor endorses you or your use."
 msgstr ""
-"  your work is derived from work that is Copyright © Software\n"
-"  Carpentry and, where practical, linking to\n"
-"  http://software-carpentry.org/), provide a [link to the\n"
-"  license][cc-by-human], and indicate if changes were made. You may do\n"
-"  so in any reasonable manner, but not in any way that suggests the\n"
-"  licensor endorses you or your use."
+"  ソフトウェアカーペントリーの著作物 (Software Carpentry©) から派生していることを記載して、\n"
+"  そして適切な場合は[http://software-carpentry.org](http://software-carpentry.org)へのリンクを表示), \n"
+"  [ライセンスへのリンク](https://creativecommons.org/licenses/by/4.0/deed.ja)を\n"
+"  提供し、変更があったらその旨を示さなければなりません。\n"
+"  これらは合理的であればどのような方法で行っても構いませんが、\n"
+"  許諾者があなたやあなたの利用行為を支持していると示唆するような方法は除きます。"
 
-#: sql-novice-survey/LICENSE.md:34
+#: shell-novice/LICENSE.md:34
 msgid ""
 "**No additional restrictions**---You may not apply legal terms or\n"
 "technological measures that legally restrict others from doing\n"
 "anything the license permits.  With the understanding that:"
 msgstr ""
-"**No additional restrictions**---You may not apply legal terms or\n"
-"technological measures that legally restrict others from doing\n"
-"anything the license permits.  With the understanding that:"
+"**追加的な制約は課せません**---あなたは、このライセンスが他の者に\n"
+"許諾することを法的に制限するようないかなる法的規定も技術的手段も\n"
+"適用してはなりません："
 
-#: sql-novice-survey/LICENSE.md:38
+#: shell-novice/LICENSE.md:38
 msgid "Notices:"
-msgstr "Notices:"
+msgstr "ご注意："
 
 # unordered list
-#: sql-novice-survey/LICENSE.md:40
+#: shell-novice/LICENSE.md:40
 msgid "* You do not have to comply with the license for elements of the"
-msgstr "* You do not have to comply with the license for elements of the"
+msgstr "* あなたは、資料の中でパブリック・ドメインに属している部分に関して、"
 
-#: sql-novice-survey/LICENSE.md:41
+#: shell-novice/LICENSE.md:41
 msgid ""
 "  material in the public domain or where your use is permitted by an\n"
 "  applicable exception or limitation.\n"
@@ -581,31 +581,31 @@ msgid ""
 "  rights such as publicity, privacy, or moral rights may limit how you\n"
 "  use the material."
 msgstr ""
-"  material in the public domain or where your use is permitted by an\n"
-"  applicable exception or limitation.\n"
-"* No warranties are given. The license may not give you all of the\n"
-"  permissions necessary for your intended use. For example, other\n"
-"  rights such as publicity, privacy, or moral rights may limit how you\n"
-"  use the material."
+"  あるいはあなたの利用が著作権法上の権利制限規定にもとづく場合には、\n"
+"  ライセンスの規定に従う必要はありません。.\n"
+"* 保証は提供されていません。ライセンスはあなたの利用に\n"
+"  必要な全ての許諾を与えないかも知れません。例えば、パブリシティ権、\n"
+"  肖像権、人格権 などの他の諸権利はあなたがどのように資料を利用するかを\n"
+"制限することがあります。"
 
 # header
-#: sql-novice-survey/LICENSE.md:48
+#: shell-novice/LICENSE.md:48
 msgid "## Software"
-msgstr "## Software"
+msgstr "## ソフトウェア"
 
-#: sql-novice-survey/LICENSE.md:50
+#: shell-novice/LICENSE.md:50
 msgid ""
 "Except where otherwise noted, the example programs and other software\n"
 "provided by Software Carpentry and Data Carpentry are made available under the\n"
 "[OSI][osi]-approved\n"
 "[MIT license][mit-license]."
 msgstr ""
-"Except where otherwise noted, the example programs and other software\n"
-"provided by Software Carpentry and Data Carpentry are made available under the\n"
-"[OSI][osi]-approved\n"
-"[MIT license][mit-license]."
+"特に記載がある場合を除いて、ソフトウェアカーペントリーおよびデータカーペントリーが\n"
+"提供しているサンプルプログラムやソフトウェアは、\n"
+"[OSI][osi]が承認した\n"
+"[MITライセンス](https://ja.osdn.net/projects/opensource/wiki/licenses%2FMIT_license)の下で利用可能です。"
 
-#: sql-novice-survey/LICENSE.md:55
+#: shell-novice/LICENSE.md:55
 msgid ""
 "Permission is hereby granted, free of charge, to any person obtaining\n"
 "a copy of this software and associated documentation files (the\n"
@@ -615,23 +615,21 @@ msgid ""
 "permit persons to whom the Software is furnished to do so, subject to\n"
 "the following conditions:"
 msgstr ""
-"Permission is hereby granted, free of charge, to any person obtaining\n"
-"a copy of this software and associated documentation files (the\n"
-"\"Software\"), to deal in the Software without restriction, including\n"
-"without limitation the rights to use, copy, modify, merge, publish,\n"
-"distribute, sublicense, and/or sell copies of the Software, and to\n"
-"permit persons to whom the Software is furnished to do so, subject to\n"
-"the following conditions:"
+"以下に定める条件に従い、本ソフトウェアおよび関連文書のファイル\n"
+"（以下「ソフトウェア」）の複製を取得するすべての人に対し、ソフトウェアを\n"
+"無制限に扱うことを無償で許可します。これには、ソフトウェアの複製を使用、\n"
+"複写、変更、結合、掲載、頒布、サブライセンス、および/または販売する権利、\n"
+"およびソフトウェアを提供する相手に同じことを許可する権利も無制限に含まれます。"
 
-#: sql-novice-survey/LICENSE.md:63
+#: shell-novice/LICENSE.md:63
 msgid ""
 "The above copyright notice and this permission notice shall be\n"
 "included in all copies or substantial portions of the Software."
 msgstr ""
-"The above copyright notice and this permission notice shall be\n"
-"included in all copies or substantial portions of the Software."
+"上記の著作権表示および本許諾表示を、ソフトウェアのすべての複製または\n"
+"重要な部分に記載するものとします。"
 
-#: sql-novice-survey/LICENSE.md:66
+#: shell-novice/LICENSE.md:66
 msgid ""
 "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
 "EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
@@ -641,28 +639,28 @@ msgid ""
 "OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
 "WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
 msgstr ""
-"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n"
-"EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF\n"
-"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n"
-"NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE\n"
-"LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION\n"
-"OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION\n"
-"WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+"ソフトウェアは「現状のまま」で、明示であるか暗黙であるかを問わず、\n"
+"何らの保証もなく提供されます。ここでいう保証とは、商品性、\n"
+"特定の目的への適合性、および権利非侵害についての保証も含みますが、\n"
+"それに限定されるものではありません。 作者または著作権者は、契約行為、\n"
+"不法行為、またはそれ以外であろうと、ソフトウェアに起因または関連し、\n"
+"あるいはソフトウェアの使用またはその他の扱いによって生じる一切の請求、\n"
+"損害、その他の義務について何らの責任も負わないものとします。"
 
 # header
-#: sql-novice-survey/LICENSE.md:74
+#: shell-novice/LICENSE.md:74
 msgid "## Trademark"
-msgstr "## Trademark"
+msgstr "## 商標"
 
-#: sql-novice-survey/LICENSE.md:76
+#: shell-novice/LICENSE.md:76
 msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
-"are registered trademarks of [Community Initiatives][CI]."
+"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"Initiatives][CI]における登録商標または商標です。"
 
-#: sql-novice-survey/LICENSE.md:79
+#: shell-novice/LICENSE.md:79
 msgid ""
 "[cc-by-human]: https://creativecommons.org/licenses/by/4.0/\n"
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
@@ -674,7 +672,8 @@ msgstr ""
 "[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode\n"
 "[mit-license]: https://opensource.org/licenses/mit-license.html\n"
 "[ci]: http://communityin.org/\n"
-"[osi]: https://opensource.org"
+"[osi]: https://opensource.org\n"
+"[osg]: https://opensource.jp"
 
 #: sql-novice-survey/README.md:1
 msgid ""

--- a/po/sql-novice-survey.ja.po
+++ b/po/sql-novice-survey.ja.po
@@ -657,7 +657,7 @@ msgid ""
 "\"Software Carpentry\" and \"Data Carpentry\" and their respective logos\n"
 "are registered trademarks of [Community Initiatives][CI]."
 msgstr ""
-"\"Software Carpentry\"と\"Data Carpentry\"およびそれぞれのロゴは[Community\n"
+"「Software Carpentry」と「Data Carpentry」およびそれぞれのロゴは[Community\n"
 "Initiatives][CI]における登録商標または商標です。"
 
 #: shell-novice/LICENSE.md:79


### PR DESCRIPTION
Migrates the License translated in PR #127 for R novice gapminder to all lessons. Also translates the title on the License webpage.

- Git novice

- Make novice

- Shell novice

- SQL novice survey

- Python novice gapminder

- Python novice inflammation

- R novice inflammation

This should be a quick one as all Japanese text has been reviewed already.