### PR TITLE
Update markdown yaml headers to support titles and links for compatibility with the theme

### DIFF
--- a/po/git-novice.ja.po
+++ b/po/git-novice.ja.po
@@ -10924,7 +10924,9 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: lesson\n"
-"root: .\n"
+"title: \"Gitでバージョン管理\""
+"root: /ja/\n"
+"permalink: /ja/index.html\n"
 "---"
 
 #: git-novice/index.md:6

--- a/po/git-novice.ja.po
+++ b/po/git-novice.ja.po
@@ -10926,7 +10926,7 @@ msgstr ""
 "layout: lesson\n"
 "title: \"Gitでバージョン管理\""
 "root: /ja/\n"
-"permalink: /ja/index.html\n"
+"permalink: /ja/\n"
 "---"
 
 #: git-novice/index.md:6

--- a/po/r-novice-gapminder.ja.po
+++ b/po/r-novice-gapminder.ja.po
@@ -21126,7 +21126,7 @@ msgstr ""
 "layout: lesson\n"
 "title: \"再現可能な科学的解析のためにR\""
 "root: /ja/\n"
-"permalink: /ja/index.html\n"
+"permalink: /ja/\n"
 "---"
 
 #: r-novice-gapminder/index.md:6

--- a/po/r-novice-gapminder.ja.po
+++ b/po/r-novice-gapminder.ja.po
@@ -21124,7 +21124,9 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: lesson\n"
-"root: .\n"
+"title: \"再現可能な科学的解析のためにR\""
+"root: /ja/\n"
+"permalink: /ja/index.html\n"
 "---"
 
 #: r-novice-gapminder/index.md:6

--- a/po/shell-novice.ja.po
+++ b/po/shell-novice.ja.po
@@ -12213,7 +12213,9 @@ msgid ""
 msgstr ""
 "---\n"
 "layout: lesson\n"
-"root: .\n"
+"title: \"Unixシェル\""
+"root: /ja/\n"
+"permalink: /ja/index.html\n"
 "---"
 
 #: shell-novice/index.md:6

--- a/po/shell-novice.ja.po
+++ b/po/shell-novice.ja.po
@@ -12215,7 +12215,7 @@ msgstr ""
 "layout: lesson\n"
 "title: \"Unixシェル\""
 "root: /ja/\n"
-"permalink: /ja/index.html\n"
+"permalink: /ja/\n"
 "---"
 
 #: shell-novice/index.md:6


### PR DESCRIPTION
The main title is defined by title: in _config.yml so would need changes to the theme to allow this to be translated.

We can add titles to the index.html files to change these labels for the "Home" button.

<img width="953" alt="Screen Shot 2020-11-16 at 18 56 52" src="https://user-images.githubusercontent.com/5493325/99239112-ef6dd200-283d-11eb-88f7-334257489c54.png">
